### PR TITLE
Yossi/heat map shader

### DIFF
--- a/Assets/Code/Behaviours/GenerateCity.cs
+++ b/Assets/Code/Behaviours/GenerateCity.cs
@@ -17,6 +17,20 @@ public class GenerateCity : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        GenerateMap();
+
+    }
+
+    private void DistroyMap()
+    {
+        foreach (Transform child in transform)
+            Destroy(child.gameObject);
+
+        _map = null;
+    }
+
+    void GenerateMap()
+    {
         _map = new Map(20, 20);
         GameObject newCube;
 
@@ -30,7 +44,7 @@ public class GenerateCity : MonoBehaviour
                 {
                     if (cell.MapCellType == Map.MapCellType.Road)
                     {
-                       
+
                         foreach (var path in cell.ConnectionPoints)
                         {
                             newCube = Instantiate<GameObject>(RoadTemplate);
@@ -48,7 +62,7 @@ public class GenerateCity : MonoBehaviour
                             newCube.SetActive(true);
                         }
                     }
-                    
+
                     if (cell.MapCellType == Map.MapCellType.Free)
                     {
                         newCube = Instantiate<GameObject>(FreeTemplate);
@@ -68,7 +82,7 @@ public class GenerateCity : MonoBehaviour
             }
         }
 
-        foreach(var intersect in _map.Intersections)
+        foreach (var intersect in _map.Intersections)
         {
             newCube = Instantiate<GameObject>(IntersectionTemplate);
             float cubeSize = cellSize / 4f;

--- a/Assets/Code/Behaviours/Material-Scripts.meta
+++ b/Assets/Code/Behaviours/Material-Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c239f41d9687de94fb125e31b0d51146
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/Behaviours/Material-Scripts/SetXrayHeatInfo.cs
+++ b/Assets/Code/Behaviours/Material-Scripts/SetXrayHeatInfo.cs
@@ -1,9 +1,15 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Experimental.GlobalIllumination;
 
+[ExecuteInEditMode]
 public class SetXrayHeatInfo : MonoBehaviour
 {
+    public GameObject spotLight;
+
+    private Material _material;
+
     private void OnEnable()
     {
         SetShader();
@@ -18,9 +24,9 @@ public class SetXrayHeatInfo : MonoBehaviour
 
     void SetShader()
     {
-        var material = GetComponent<Renderer>().material;
-        material.SetInt("_HeatPointsCount", 6);
-        material.SetVectorArray("_HeatPoints", new List<Vector4>()
+        _material = GetComponent<Renderer>().material;
+        _material.SetInt("_HeatPointsCount", 6);
+        _material.SetVectorArray("_HeatPoints", new List<Vector4>()
         {
             new Vector4(1f, 0f, 0f, 1f),
             new Vector4(0f, 1f, 0f, 1f),
@@ -31,9 +37,9 @@ public class SetXrayHeatInfo : MonoBehaviour
             new Vector4(0f, 0f, -1f, 1f)
         });
 
-        float intensity = 1.8f;
-        float size = 1.2f;
-        material.SetFloatArray("_Intensitys", new List<float>()
+        float intensity = 1.5f;
+        float size = 1.3f;
+        _material.SetFloatArray("_Intensitys", new List<float>()
         {
             intensity,
             intensity,
@@ -44,7 +50,7 @@ public class SetXrayHeatInfo : MonoBehaviour
             intensity
         });
 
-        material.SetFloatArray("_HeatSizes", new List<float>()
+        _material.SetFloatArray("_HeatSizes", new List<float>()
         {
             size,
             size,
@@ -54,11 +60,20 @@ public class SetXrayHeatInfo : MonoBehaviour
             size,
             size
         });
+        SetLightInfo();
     }
 
-    // Update is called once per frame
-    //void Update()
-    //{
+    void SetLightInfo()
+    {
+        _material.SetVector("_LightPos", spotLight.transform.position);
         
-    //}
+        //var spotlightNormal = spotLight.orientation * (new Vector4(0, 0, 1, 1));
+        _material.SetVector("_LightDirection", spotLight.transform.forward);
+    }
+
+    //Update is called once per frame
+    void Update()
+    {
+        SetLightInfo();
+    }
 }

--- a/Assets/Code/Behaviours/Material-Scripts/SetXrayHeatInfo.cs
+++ b/Assets/Code/Behaviours/Material-Scripts/SetXrayHeatInfo.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SetXrayHeatInfo : MonoBehaviour
+{
+    private void OnEnable()
+    {
+        SetShader();
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        SetShader();
+        //
+    }
+
+    void SetShader()
+    {
+        var material = GetComponent<Renderer>().material;
+        material.SetInt("_HeatPointsCount", 6);
+        material.SetVectorArray("_HeatPoints", new List<Vector4>()
+        {
+            new Vector4(1f, 0f, 0f, 1f),
+            new Vector4(0f, 1f, 0f, 1f),
+            new Vector4(0f, 0f, 1f, 1f),
+
+            new Vector4(-1f, 0f, 0f, 1f),
+            new Vector4(0f, -1f, 0f, 1f),
+            new Vector4(0f, 0f, -1f, 1f)
+        });
+
+        float intensity = 1.8f;
+        float size = 1.2f;
+        material.SetFloatArray("_Intensitys", new List<float>()
+        {
+            intensity,
+            intensity,
+            intensity,
+
+            intensity,
+            intensity,
+            intensity
+        });
+
+        material.SetFloatArray("_HeatSizes", new List<float>()
+        {
+            size,
+            size,
+            size,
+            
+            size,
+            size,
+            size
+        });
+    }
+
+    // Update is called once per frame
+    //void Update()
+    //{
+        
+    //}
+}

--- a/Assets/Code/Behaviours/Material-Scripts/SetXrayHeatInfo.cs.meta
+++ b/Assets/Code/Behaviours/Material-Scripts/SetXrayHeatInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f324f71e61f6bf459f81763bd41398a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/Behaviours/Material-Scripts/XRayReplacement.cs
+++ b/Assets/Code/Behaviours/Material-Scripts/XRayReplacement.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+[ExecuteInEditMode]
+public class XRayReplacement : MonoBehaviour
+{
+    public Shader XRayShader;
+
+    void OnEnable()
+    {
+        GetComponent<Camera>().SetReplacementShader(XRayShader, "XRay");
+    }
+}

--- a/Assets/Code/Behaviours/Material-Scripts/XRayReplacement.cs.meta
+++ b/Assets/Code/Behaviours/Material-Scripts/XRayReplacement.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1a83e2f8d0f5cf145bede633d59878cd
+timeCreated: 1466804445
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/Behaviours/Spinner.cs
+++ b/Assets/Code/Behaviours/Spinner.cs
@@ -1,0 +1,13 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+public class Spinner : MonoBehaviour
+{
+    public Vector3 RotationPerSecond;
+
+	void Update ()
+	{
+        transform.Rotate(RotationPerSecond * Time.deltaTime);
+	}
+}

--- a/Assets/Code/Behaviours/Spinner.cs.meta
+++ b/Assets/Code/Behaviours/Spinner.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 79d98194780f10c4cb3a543727482507
+timeCreated: 1467133853
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/HeatVision-Object.mat
+++ b/Assets/Materials/HeatVision-Object.mat
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HeatVision-Object
+  m_Shader: {fileID: 4800000, guid: 0a8a33aed56087c4bb6f8272cae4dfa5, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Alpha: 0.62
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0, g: 1, b: 0.9378109, a: 1}
+    - _EdgeColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Materials/HeatVision-Object.mat.meta
+++ b/Assets/Materials/HeatVision-Object.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 88bbbf1c99059d444a5c3a35905754e4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/HeatVision-Ray.mat
+++ b/Assets/Materials/HeatVision-Ray.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HeatVision-Ray
+  m_Shader: {fileID: 4800000, guid: 3710351f4949d3749ba82cad2647379f, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Materials/HeatVision-Ray.mat.meta
+++ b/Assets/Materials/HeatVision-Ray.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 381928f4fa7bdac4783c82610bac348c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/HeatVision-Standart.mat
+++ b/Assets/Materials/HeatVision-Standart.mat
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HeatVision-Standart
+  m_Shader: {fileID: 4800000, guid: a1748d910075a8149a533f784d95298b, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Alpha: 0.512
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EdgeColor: {r: 0, g: 0.9811321, b: 0.97094864, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Materials/HeatVision-Standart.mat.meta
+++ b/Assets/Materials/HeatVision-Standart.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d9133bd058cd4be4bac2d9b0374a8f89
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -139,7 +139,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &68942669
 Transform:
   m_ObjectHideFlags: 0
@@ -955,6 +955,83 @@ Transform:
   m_Father: {fileID: 300037703}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &861980042
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HeatVision-Standart (Instance) (Instance) (Instance)
+  m_Shader: {fileID: 4800000, guid: a1748d910075a8149a533f784d95298b, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Alpha: 0.512
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EdgeColor: {r: 0, g: 0.9811321, b: 0.97094864, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -1193,13 +1270,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1137982811}
-  m_LocalRotation: {x: 0.0824464, y: -0.6620832, z: 0.07185515, w: 0.7414076}
-  m_LocalPosition: {x: 0, y: 1.94, z: -0.22}
+  m_LocalRotation: {x: -0.12882747, y: 0.11224835, z: -0.0146781355, w: -0.98518443}
+  m_LocalPosition: {x: -0.37, y: 2, z: -0.22}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1352628719}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 12.556001, y: -83.547005, z: -0.15400001}
+  m_LocalEulerAnglesHint: {x: 14.9, y: 1787, z: 0}
 --- !u!108 &1137982813
 Light:
   m_ObjectHideFlags: 0
@@ -1211,8 +1288,8 @@ Light:
   serializedVersion: 10
   m_Type: 0
   m_Shape: 0
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Intensity: 1
+  m_Color: {r: 1, g: 0.754717, b: 0.754717, a: 1}
+  m_Intensity: 10
   m_Range: 10.982784
   m_SpotAngle: 29.2
   m_InnerSpotAngle: 21.80208
@@ -1817,7 +1894,6 @@ GameObject:
   - component: {fileID: 1665557118}
   - component: {fileID: 1665557122}
   - component: {fileID: 1665557123}
-  - component: {fileID: 1665557124}
   m_Layer: 0
   m_Name: Sphere
   m_TagString: Untagged
@@ -1856,7 +1932,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 88bbbf1c99059d444a5c3a35905754e4, type: 2}
+  - {fileID: 861980042}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -1892,13 +1968,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1665557117}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 78.9, y: 5.37, z: 12.5}
+  m_LocalRotation: {x: 0, y: 0.20022298, z: 0, w: 0.9797504}
+  m_LocalPosition: {x: 10.13, y: 1.62, z: -18.88}
   m_LocalScale: {x: 4.4043, y: 4.4043, z: 4.4043}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 23.1, z: 0}
 --- !u!114 &1665557122
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1924,19 +2000,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1f324f71e61f6bf459f81763bd41398a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &1665557124
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1665557117}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 79d98194780f10c4cb3a543727482507, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  RotationPerSecond: {x: 0, y: 0, z: 0}
+  spotLight: {fileID: 1352628718}
 --- !u!1 &1809666871
 GameObject:
   m_ObjectHideFlags: 0
@@ -2028,13 +2092,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2088809536}
-  m_LocalRotation: {x: 0, y: 0, z: -0.6427876, w: 0.7660445}
-  m_LocalPosition: {x: -5.640001, y: 0.35, z: 0.87000036}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0.35, z: 6.6}
   m_LocalScale: {x: 6, y: 4.81615, z: 6}
   m_Children: []
   m_Father: {fileID: 1352628719}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -80}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!23 &2088809538
 MeshRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -121,6 +121,103 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &68942668
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 68942669}
+  - component: {fileID: 68942671}
+  - component: {fileID: 68942670}
+  - component: {fileID: 68942672}
+  m_Layer: 0
+  m_Name: Heat Vision Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &68942669
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 68942668}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 963194228}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!81 &68942670
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 68942668}
+  m_Enabled: 0
+--- !u!20 &68942671
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 68942668}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 4
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &68942672
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 68942668}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a83e2f8d0f5cf145bede633d59878cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  XRayShader: {fileID: 4800000, guid: ffb57f77504d1d24eb8c21861da7f082, type: 3}
 --- !u!1 &112643926
 GameObject:
   m_ObjectHideFlags: 0
@@ -939,7 +1036,8 @@ Transform:
   m_LocalRotation: {x: 0.23143351, y: 0.6420502, z: -0.21247731, w: 0.6993308}
   m_LocalPosition: {x: 10.32, y: 2.94, z: -0.45}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 68942669}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 27.414001, y: -92.30701, z: 1.013}
@@ -1071,6 +1169,98 @@ Transform:
   m_Father: {fileID: 300037703}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1 &1137982811
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1137982812}
+  - component: {fileID: 1137982813}
+  m_Layer: 0
+  m_Name: Spot Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1137982812
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137982811}
+  m_LocalRotation: {x: 0.0824464, y: -0.6620832, z: 0.07185515, w: 0.7414076}
+  m_LocalPosition: {x: 0, y: 1.94, z: -0.22}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1352628719}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 12.556001, y: -83.547005, z: -0.15400001}
+--- !u!108 &1137982813
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137982811}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 0
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10.982784
+  m_SpotAngle: 29.2
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
 --- !u!1 &1152441535 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1522545123835681044, guid: cc8daf03157b2b94b8fbba22b8232e0e,
@@ -1373,6 +1563,52 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1300163655}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1352628718
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1352628719}
+  - component: {fileID: 1352628720}
+  m_Layer: 0
+  m_Name: HeatVision-Rotation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1352628719
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1352628718}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2088809537}
+  - {fileID: 1137982812}
+  m_Father: {fileID: 1442268798}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1352628720
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1352628718}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79d98194780f10c4cb3a543727482507, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  RotationPerSecond: {x: 0, y: 100, z: 0}
 --- !u!1 &1393558983
 GameObject:
   m_ObjectHideFlags: 0
@@ -1511,6 +1747,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1300163660}
+  - {fileID: 1352628719}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
@@ -1566,6 +1803,140 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   GenerateCity: {fileID: 1211649471}
+--- !u!1 &1665557117
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1665557121}
+  - component: {fileID: 1665557120}
+  - component: {fileID: 1665557119}
+  - component: {fileID: 1665557118}
+  - component: {fileID: 1665557122}
+  - component: {fileID: 1665557123}
+  - component: {fileID: 1665557124}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!135 &1665557118
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1665557117}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1665557119
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1665557117}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 88bbbf1c99059d444a5c3a35905754e4, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1665557120
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1665557117}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1665557121
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1665557117}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 78.9, y: 5.37, z: 12.5}
+  m_LocalScale: {x: 4.4043, y: 4.4043, z: 4.4043}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1665557122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1665557117}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac06f671fa493a84e9e021bcb8a3deb0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GenerateCity: {fileID: 1211649471}
+--- !u!114 &1665557123
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1665557117}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f324f71e61f6bf459f81763bd41398a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1665557124
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1665557117}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79d98194780f10c4cb3a543727482507, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  RotationPerSecond: {x: 0, y: 0, z: 0}
 --- !u!1 &1809666871
 GameObject:
   m_ObjectHideFlags: 0
@@ -1632,3 +2003,82 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2088809536
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2088809537}
+  - component: {fileID: 2088809539}
+  - component: {fileID: 2088809538}
+  m_Layer: 0
+  m_Name: Heat Vision Ray
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2088809537
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2088809536}
+  m_LocalRotation: {x: 0, y: 0, z: -0.6427876, w: 0.7660445}
+  m_LocalPosition: {x: -5.640001, y: 0.35, z: 0.87000036}
+  m_LocalScale: {x: 6, y: 4.81615, z: 6}
+  m_Children: []
+  m_Father: {fileID: 1352628719}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -80}
+--- !u!23 &2088809538
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2088809536}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 381928f4fa7bdac4783c82610bac348c, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &2088809539
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2088809536}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -955,83 +955,6 @@ Transform:
   m_Father: {fileID: 300037703}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &861980042
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: HeatVision-Standart (Instance) (Instance) (Instance)
-  m_Shader: {fileID: 4800000, guid: a1748d910075a8149a533f784d95298b, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _DetailAlbedoMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _DetailMask:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _DetailNormalMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _ParallaxMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - _Alpha: 0.512
-    - _BumpScale: 1
-    - _Cutoff: 0.5
-    - _DetailNormalMapScale: 1
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _Mode: 0
-    - _OcclusionStrength: 1
-    - _Parallax: 0.02
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _UVSec: 0
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _EdgeColor: {r: 0, g: 0.9811321, b: 0.97094864, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -1270,13 +1193,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1137982811}
-  m_LocalRotation: {x: -0.12882747, y: 0.11224835, z: -0.0146781355, w: -0.98518443}
-  m_LocalPosition: {x: -0.37, y: 2, z: -0.22}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0, y: 0, z: 1.721}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1352628719}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 14.9, y: 1787, z: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!108 &1137982813
 Light:
   m_ObjectHideFlags: 0
@@ -1288,11 +1211,11 @@ Light:
   serializedVersion: 10
   m_Type: 0
   m_Shape: 0
-  m_Color: {r: 1, g: 0.754717, b: 0.754717, a: 1}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
   m_Intensity: 10
   m_Range: 10.982784
-  m_SpotAngle: 29.2
-  m_InnerSpotAngle: 21.80208
+  m_SpotAngle: 50
+  m_InnerSpotAngle: 5
   m_CookieSize: 10
   m_Shadows:
     m_Type: 0
@@ -1331,7 +1254,7 @@ Light:
   m_Lightmapping: 4
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
-  m_BounceIntensity: 1
+  m_BounceIntensity: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
@@ -1664,15 +1587,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1352628718}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0.030322976, y: -0.62861216, z: 0.025554448, w: 0.7767073}
+  m_LocalPosition: {x: -0.43, y: 2.04, z: 0.07}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 2088809537}
   - {fileID: 1137982812}
   m_Father: {fileID: 1442268798}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 4.544, y: -77.965004, z: 0.09}
 --- !u!114 &1352628720
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1880,6 +1802,88 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   GenerateCity: {fileID: 1211649471}
+--- !u!21 &1471130372
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HeatVision-Standart (Instance) (Instance) (Instance) (Instance) (Instance)
+    (Instance)
+  m_Shader: {fileID: 4800000, guid: a1748d910075a8149a533f784d95298b, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Alpha: 0.512
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _LightAngle: 30
+    - _LightIntensity: 1
+    - _LightLengthMax: 40
+    - _LightLengthMin: 15
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EdgeColor: {r: 0, g: 0.9811321, b: 0.97094864, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
 --- !u!1 &1665557117
 GameObject:
   m_ObjectHideFlags: 0
@@ -1895,12 +1899,12 @@ GameObject:
   - component: {fileID: 1665557122}
   - component: {fileID: 1665557123}
   m_Layer: 0
-  m_Name: Sphere
+  m_Name: Example of Person with the shader
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!135 &1665557118
 SphereCollider:
   m_ObjectHideFlags: 0
@@ -1932,7 +1936,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 861980042}
+  - {fileID: 1471130372}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -2067,82 +2071,3 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2088809536
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2088809537}
-  - component: {fileID: 2088809539}
-  - component: {fileID: 2088809538}
-  m_Layer: 0
-  m_Name: Heat Vision Ray
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2088809537
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2088809536}
-  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0.35, z: 6.6}
-  m_LocalScale: {x: 6, y: 4.81615, z: 6}
-  m_Children: []
-  m_Father: {fileID: 1352628719}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &2088809538
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2088809536}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 381928f4fa7bdac4783c82610bac348c, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &2088809539
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2088809536}
-  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Shaders.meta
+++ b/Assets/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: abfb58499abb4e7439c6998755c697da
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/HeatVision-Shader.shader
+++ b/Assets/Shaders/HeatVision-Shader.shader
@@ -1,0 +1,158 @@
+﻿// Upgrade NOTE: replaced '_Object2World' with 'unity_ObjectToWorld'
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
+Shader "Custom/HeatVision"
+{
+	Properties
+	{
+		_EdgeColor("Edge Color", Color) = (1,1,1,1)
+		_LightLengthMax("HeatVision Ray Far Range", Float) = 40
+		_LightLengthMin("HeatVision Ray Close Range", Float) = 15
+		_LightIntensity("HeatVision Ray Intensity", Range(0,10)) = 1
+		_LightAngle("HeatVision Ray Angle", Float) = 30
+	}
+
+	SubShader
+	{
+		Tags
+		{
+			"RenderType" = "Opaque"
+			"XRay" = "ColoredOutline"
+		}
+
+		Pass
+		{
+
+			CGPROGRAM
+
+			#pragma vertex vert
+			#pragma fragment frag
+			
+			#include "UnityCG.cginc"
+			#define MAX_HEATPOINTS 10
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float2 uv : TEXCOORD0;
+				float3 normal : NORMAL;
+			};
+
+			struct v2f
+			{
+				float2 uv : TEXCOORD0;
+				float4 vertex : SV_POSITION;
+				float3 normal : NORMAL;
+				float3 viewDir : TEXCOORD1;
+				float4 pixelPos: POSITION1;
+				float4 worldPixelPos: POSITION2;
+				float4 viewPixelPos: POSITION3;
+			};
+
+			v2f vert (appdata v)
+			{
+				v2f o;
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.uv = v.uv;
+				o.pixelPos = v.vertex;
+				o.worldPixelPos =  mul(unity_ObjectToWorld, v.vertex);
+				o.normal = UnityObjectToWorldNormal(v.normal);
+				o.viewDir = normalize(_WorldSpaceCameraPos.xyz - mul(unity_ObjectToWorld, v.vertex).xyz);
+				return o;
+			}
+
+			float4 _EdgeColor;
+			
+			float _LightLengthMax = 40;
+			float _LightLengthMin = 15;
+			float _LightIntensity = 1;
+			float _LightAngle = 30.0;
+
+			float4 _HeatPoints[MAX_HEATPOINTS];
+			float _Intensitys[MAX_HEATPOINTS];
+			float _HeatSizes[MAX_HEATPOINTS];
+			int _HeatPointsCount;
+
+			float4 _LightPos;
+			float4 _LightDirection;
+
+			float getAngle3(float3 v1, float3 v2){
+				float dt = dot(v1, v2);
+				float angle = acos(dt / (length(v1)*length(v2)));
+				return degrees(angle);
+			}
+
+			float getAngle4(float4 v1, float4 v2){
+				float dt = dot(v1, v2);
+				float angle = acos(dt / (length(v1)*length(v2)));
+				return degrees(angle);
+			}			
+
+			fixed4 frag (v2f i) : SV_Target
+			{
+				fixed4 realPixelColor = fixed4(1,1,1,1);
+
+				// Heat Calculation
+				float NdotV = 1 - dot(i.normal, i.viewDir) * 1.5;
+				
+				float minLength = 32000;
+				float selectedIntensity = 0;
+				float selectedHeatLength = 0;
+				
+				int indx;
+				[loop]
+				for (indx = 0; indx < _HeatPointsCount; indx++){
+				
+					float currLength = length(i.pixelPos - float4(_HeatPoints[indx].x,_HeatPoints[indx].y,_HeatPoints[indx].z,1));
+					if (currLength <= minLength){
+						minLength = currLength;
+						selectedIntensity = _Intensitys[indx];
+						selectedHeatLength = _HeatSizes[indx];
+					}
+				}
+
+				float heatIntensity = minLength;//length(i.pixelPos - float4(0,0,0,1));
+				float intensity = selectedIntensity * (1.0 - abs(sin(_Time.z)+cos(_Time.z)) * 0.1);
+
+				// heatIntensity = 0 - means Hotest spot.
+				fixed3 col = fixed3(
+					lerp(0, 1, max(0, 1 - (min(selectedHeatLength, heatIntensity) + 0.1) / selectedHeatLength) * intensity),
+					lerp(0, 1, max(0, 1 - (min(selectedHeatLength, heatIntensity) + 0.1 + 0.4 / intensity) / selectedHeatLength) * intensity),
+					lerp(1, 0, 1 - min(selectedHeatLength, heatIntensity) / selectedHeatLength  + 0.2)
+				);
+				
+				fixed4 heatColor = (fixed4(max(0,col.r), max(0,col.g), max(0,col.b), 1) * (1 - NdotV) + _EdgeColor * NdotV);
+
+				// Light Calculation
+				float4 pointN = float4(i.normal.x, i.normal.y, i.normal.z, 1);
+				float4 pointPos = i.worldPixelPos;
+				float4 lightPos = _LightPos;
+				float4 lightN = _LightDirection;
+
+				float4 lightDirection = _LightDirection;
+				float  lightLengthMax = _LightLengthMax;
+				float  lightLengthMin = _LightLengthMin;
+				float  lightIntensity = _LightIntensity;
+				float  lightAngle =_LightAngle;
+				
+				float4 distanceToLight = i.worldPixelPos - lightPos;
+				
+				float lightToPixelLength = length(distanceToLight);
+				
+				
+				float4 diff = pointPos - lightPos;
+				float4 diffN = normalize(diff);
+				float4 refdiff = normalize(reflect(diff, pointN));
+				float4 refLightN = reflect(lightN, pointN);
+				
+				float positionIntensity =  dot(refdiff, pointN) * (1 - min(1, max(0, length(diff) - lightLengthMin) / max(1, lightLengthMax - lightLengthMin)) ); // Need to make the diff length relevant.
+				float directionIntensity = dot(lightN, diffN) * (1 - min(1, abs(getAngle4(lightN, diffN) / lightAngle))); // Need to make the light angle relevant
+				float totalLightIntensity = positionIntensity * directionIntensity;
+
+				return heatColor * lightIntensity * totalLightIntensity + (1 - totalLightIntensity) * realPixelColor;
+			}
+
+			ENDCG
+		}
+	}
+}

--- a/Assets/Shaders/HeatVision-Shader.shader.meta
+++ b/Assets/Shaders/HeatVision-Shader.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a1748d910075a8149a533f784d95298b
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/Normal-Diffuse-XRay-Replaceable.shader
+++ b/Assets/Shaders/Normal-Diffuse-XRay-Replaceable.shader
@@ -1,0 +1,52 @@
+Shader "XRay Shaders/Diffuse-XRay-Replaceable"
+{
+	Properties
+	{
+		_Color("Main Color", Color) = (1,1,1,1)
+		_Alpha("Alpha", Range(0,1)) = 1.0
+		_EdgeColor("XRay Edge Color", Color) = (0,0,0,0)
+		_MainTex("Base (RGB)", 2D) = "white" {}
+	}
+
+	SubShader
+	{
+		Tags
+		{
+			//////////////////////////////////////////////////////////////////////////////////////////////////////
+			// In some cases, it's necessary to force XRay objects to render before the rest of the geometry	//
+			// This is so their depth info is already in the ZBuffer, and Occluding objects won't mistakenly	//
+			// write to the Stencil buffer when they shouldn't.													//
+			//																									//
+			// This is what "Queue" = "Geometry-1" is for.														//
+			// I didn't bring this up in the video because I'm an idiot.										//
+			//																									//
+			// Cheers,																							//
+			// Dan																								//
+			//////////////////////////////////////////////////////////////////////////////////////////////////////
+			"Queue" = "Geometry-1"
+			"RenderType" = "Opaque"
+			"XRay" = "ColoredOutline"
+		}
+		LOD 200
+
+		CGPROGRAM
+		#pragma surface surf Lambert
+
+		sampler2D _MainTex;
+		fixed4 _Color;
+
+		struct Input {
+			float2 uv_MainTex;
+		};
+
+		void surf(Input IN, inout SurfaceOutput o)
+		{
+			fixed4 c = tex2D(_MainTex, IN.uv_MainTex) * _Color;
+			o.Albedo = c.rgb;
+			o.Alpha = c.a;
+		}
+		ENDCG
+	}
+	
+	Fallback "Legacy Shaders/VertexLit"
+}

--- a/Assets/Shaders/Normal-Diffuse-XRay-Replaceable.shader.meta
+++ b/Assets/Shaders/Normal-Diffuse-XRay-Replaceable.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 0a8a33aed56087c4bb6f8272cae4dfa5
+timeCreated: 1469048226
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/XRay-HeatVision.shader
+++ b/Assets/Shaders/XRay-HeatVision.shader
@@ -1,0 +1,114 @@
+﻿// Upgrade NOTE: replaced '_Object2World' with 'unity_ObjectToWorld'
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
+Shader "XRay Shaders/HeatVision"
+{
+	Properties
+	{
+		_EdgeColor("Edge Color", Color) = (1,1,1,1)
+		_Alpha("Alpha", Range(0,1)) = 1.0
+	}
+
+	SubShader
+	{
+		Stencil
+		{
+			Ref 0
+			Comp NotEqual
+		}
+
+		Tags
+		{
+			"Queue" = "Transparent"
+			"RenderType" = "Transparent"
+			"XRay" = "ColoredOutline"
+		}
+
+		ZWrite Off
+		ZTest Always
+		Blend SrcAlpha OneMinusSrcAlpha
+
+		Pass
+		{
+
+			CGPROGRAM
+
+			#pragma vertex vert
+			#pragma fragment frag
+			
+			#include "UnityCG.cginc"
+			#define MAX_HEATPOINTS 10
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float2 uv : TEXCOORD0;
+				float3 normal : NORMAL;
+			};
+
+			struct v2f
+			{
+				float2 uv : TEXCOORD0;
+				float4 vertex : SV_POSITION;
+				float3 normal : NORMAL;
+				float3 viewDir : TEXCOORD1;
+				float4 pixelPos: POSITION1;
+				float4 viewPixelPos: POSITION2;
+			};
+
+			v2f vert (appdata v)
+			{
+				v2f o;
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.uv = v.uv;
+				o.pixelPos = v.vertex;
+				o.normal = UnityObjectToWorldNormal(v.normal);
+				o.viewDir = normalize(_WorldSpaceCameraPos.xyz - mul(unity_ObjectToWorld, v.vertex).xyz);
+				return o;
+			}
+
+			float4 _EdgeColor;
+			float _Alpha;
+			float4 _HeatPoints[MAX_HEATPOINTS];
+			float _Intensitys[MAX_HEATPOINTS];
+			float _HeatSizes[MAX_HEATPOINTS];
+			int _HeatPointsCount;
+
+			fixed4 frag (v2f i) : SV_Target
+			{
+				float NdotV = 1 - dot(i.normal, i.viewDir) * 1.5;
+				
+				float minLength = 32000;
+				float selectedIntensity = 0;
+				float selectedHeatLength = 0;
+				
+				
+				int indx;
+				[loop]
+				for (indx = 0; indx < _HeatPointsCount; indx++){
+				
+					float currLength = length(i.pixelPos - float4(_HeatPoints[indx].x,_HeatPoints[indx].y,_HeatPoints[indx].z,1));
+					if (currLength <= minLength){
+						minLength = currLength;
+						selectedIntensity = _Intensitys[indx];
+						selectedHeatLength = _HeatSizes[indx];
+					}
+				}
+
+				float heatIntensity = minLength;//length(i.pixelPos - float4(0,0,0,1));
+				float intensity = selectedIntensity * (1.0 - abs(sin(_Time.z)+cos(_Time.z)) * 0.1);
+
+				// heatIntensity = 0 - means Hotest spot.
+				fixed3 col = fixed3(
+					lerp(0, 1, max(0, 1 - (min(selectedHeatLength, heatIntensity) + 0.1) / selectedHeatLength) * intensity),
+					lerp(0, 1, max(0, 1 - (min(selectedHeatLength, heatIntensity) + 0.1 + 0.4 / intensity) / selectedHeatLength) * intensity),
+					lerp(1, 0, 1 - min(selectedHeatLength, heatIntensity) / selectedHeatLength  + 0.2)
+				);
+				
+				return (fixed4(col.r, col.g, col.b, 0) * (1 - NdotV) + _EdgeColor * NdotV) * fixed4(1,1,1,0) + fixed4(0,0,0,_Alpha);
+			}
+
+			ENDCG
+		}
+	}
+}

--- a/Assets/Shaders/XRay-HeatVision.shader.meta
+++ b/Assets/Shaders/XRay-HeatVision.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ffb57f77504d1d24eb8c21861da7f082
+timeCreated: 1466797765
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/Xray-RayPreperation.shader
+++ b/Assets/Shaders/Xray-RayPreperation.shader
@@ -1,0 +1,43 @@
+Shader "XRay Shaders/Ray Preperation"
+{
+	Properties
+	{
+		_Color("Main Color", Color) = (1,1,1,1)
+		_MainTex("Base (RGB)", 2D) = "white" {}
+	}
+
+	SubShader
+	{
+		Tags { "RenderType" = "Transparent" }
+		LOD 200
+		//Cull Back
+		Blend Zero One
+		Stencil
+		{
+			Ref 1
+			Comp Always
+			Pass Replace
+			ZFail Keep
+		}
+
+		CGPROGRAM
+		#pragma surface surf Lambert
+
+		sampler2D _MainTex;
+		fixed4 _Color;
+
+		struct Input {
+			float2 uv_MainTex;
+		};
+
+		void surf(Input IN, inout SurfaceOutput o)
+		{
+			//fixed4 c = tex2D(_MainTex, IN.uv_MainTex) * _Color;
+			o.Albedo = fixed3(0,0,0)//c.rgb;
+			o.Alpha = 1;
+		}
+		ENDCG
+	}
+	
+	Fallback "Legacy Shaders/VertexLit"
+}

--- a/Assets/Shaders/Xray-RayPreperation.shader
+++ b/Assets/Shaders/Xray-RayPreperation.shader
@@ -33,7 +33,7 @@ Shader "XRay Shaders/Ray Preperation"
 		void surf(Input IN, inout SurfaceOutput o)
 		{
 			//fixed4 c = tex2D(_MainTex, IN.uv_MainTex) * _Color;
-			o.Albedo = fixed3(0,0,0)//c.rgb;
+			o.Albedo = fixed3(0,0,0);//c.rgb;
 			o.Alpha = 1;
 		}
 		ENDCG

--- a/Assets/Shaders/Xray-RayPreperation.shader.meta
+++ b/Assets/Shaders/Xray-RayPreperation.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 3710351f4949d3749ba82cad2647379f
+timeCreated: 1467139813
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add two different types of heat map shaders.
1. allows to add a heat vision for objects that are not seeing in the scene.
2. Add a heat vision effect for object that are lightened by a sort of spotlight heat vision ray effect.